### PR TITLE
Fix PDF background color option

### DIFF
--- a/src/pdf/createPdf.ts
+++ b/src/pdf/createPdf.ts
@@ -13,7 +13,7 @@ export async function createPdf(containerElement: HTMLElement): Promise<Blob> {
 
     const canvas = await html2canvas(containerElement, {
         scale: 3 /* TODO: @hejny What is the ideal quality */,
-        backgroundColor: 'trasparent',
+        backgroundColor: 'transparent',
         allowTaint: true,
         // removeContainer: true,
         ignoreElements: (element) => {


### PR DESCRIPTION
## Summary
- correct `backgroundColor` property value in `createPdf` util

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_684083d6b3cc83279c3ca17f08a9d0b3